### PR TITLE
Add nicer error message when using unregistered object type

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -190,4 +190,14 @@ describe('Telepath', () => {
     expect(discography[1].title).toBe('Beyoncé');
     expect(discography[1].artists[0].name).toBe('Beyoncé');
   });
+
+  it('fails to unpack unknown type', () => {
+    expect(() => telepath.unpack([
+        {
+          _type: 'unknown.Unknown',
+          _args: []
+        },
+      ])
+    ).toThrow('telepath encountered unknown object type unknown.Unknown');
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,9 @@ class Telepath {
       /* handle as a custom type */
       const constructorId = objData['_type'];
       const constructor = this.constructors[constructorId];
+      if (typeof constructor !== 'function') {
+        throw new Error(`telepath encountered unknown object type ${constructorId}`);
+      }
       /* unpack arguments recursively */
       const args = objData['_args'].map(arg => this.unpackWithRefs(arg, packedValuesById, valuesById));
       result = new constructor(...args);


### PR DESCRIPTION
Fixes #3

Went with a simple function check, that'll catch most of the cases. It's [possible](https://stackoverflow.com/a/46320004) to do a constructor check, although the code is much less readable.